### PR TITLE
Fix csv-parse error when player has quotation mark in name

### DIFF
--- a/js/core/stores/airbossStore.ts
+++ b/js/core/stores/airbossStore.ts
@@ -62,7 +62,7 @@ export default class AirbossStore {
     async readTrackingFile(firstTime: boolean) {
         try {
             const buffer = await readFile(this.filePath, {encoding: 'utf-8'})
-            const csv = parse(buffer, {skip_empty_lines: true, columns: true})
+            const csv = parse(buffer, {quote: '', skip_empty_lines: true, columns: true})
             const newTraps: Trap[] = csv.map((entry: Object) => trapFromCSVEntry(entry));
             const orderedTraps = newTraps.sort((a, b) => b.date.getTime() - a.date.getTime())
             if (!firstTime && this.cache.currentTraps.length !== orderedTraps.length) {


### PR DESCRIPTION
Currently, if a player has a quotation mark in their name, it will cause an error in the csv-parse module 

> Unable to read file C:/Users/****/Saved Games/DCS.openbeta_server/Greenie Board.csv error { Error: Invalid Opening Quote: a quote is found inside a field at line 8
>     at Parser.__parse (C:\BTI\js\core\node_modules\csv-parse\lib\index.js:487:19)
>     at Object.module.exports [as default] (C:\BTI\js\core\node_modules\csv-parse\lib\sync.js:17:23)
>     at AirbossStore.<anonymous> (C:\BTI\js\core\build\stores\airbossStore.js:73:43)
>     at Generator.next (<anonymous>)
>     at fulfilled (C:\BTI\js\core\build\stores\airbossStore.js:4:58)

This fixes it by disabling the quote character (") in the csv-parser options.