### PR TITLE
Improve WOFD on Greenie Board

### DIFF
--- a/js/live/src/model/trap.ts
+++ b/js/live/src/model/trap.ts
@@ -1,6 +1,6 @@
 export default interface Trap {
     pilotName: string,
-    points: string,
+    points: number,
     totalPoints?: number,
     grade: string,
     detail: string,

--- a/js/live/src/model/trap.ts
+++ b/js/live/src/model/trap.ts
@@ -1,6 +1,6 @@
 export default interface Trap {
     pilotName: string,
-    points: number,
+    points: string,
     totalPoints?: number,
     grade: string,
     detail: string,

--- a/js/live/src/ui/Airboss.tsx
+++ b/js/live/src/ui/Airboss.tsx
@@ -63,18 +63,16 @@ export default class Airboss extends React.Component<Props, State> {
         setInterval(() => this.refreshData(), 30000);
     }
 
-    private styleForGrade(grade: string): CSSProperties {
-        if (grade === "5.0") {
+    private styleForGrade(grade: number): CSSProperties {
+        if (grade >= 5.0) {
             return { backgroundColor: 'green' }
-        } else if (grade === "3.0" || grade === "4.0") {
+        } else if (grade >= 3.0) {
             return { backgroundColor: '#006400' }
-        } else if (grade === "2.0" || grade === "2.5") {
+        } else if (grade >= 2.0) {
             return { backgroundColor: 'gray' }
-        } else if (grade === "1.0") {
+        } else if (grade >= 1.0) {
             return { backgroundColor: 'orange' }
-        } else if (grade === "NC") {
-			return { backgroundColor: 'gray' }
-		}
+        }
         return { backgroundColor: 'red' }
 
     }
@@ -98,9 +96,6 @@ export default class Airboss extends React.Component<Props, State> {
                     </thead>
                     <tbody>
                         {this.state.currentTraps.map((trap: Trap) => {
-							if (trap.points === "-1.0") {
-								trap.points = "NC"
-							}
                             const gradeStyle = this.styleForGrade(trap.points)
                             return (
                                 <tr style={{ ...styleCell, ...gradeStyle}} key={trap.pilotName + trap.grade + trap.detail}>

--- a/js/live/src/ui/Airboss.tsx
+++ b/js/live/src/ui/Airboss.tsx
@@ -63,16 +63,18 @@ export default class Airboss extends React.Component<Props, State> {
         setInterval(() => this.refreshData(), 30000);
     }
 
-    private styleForGrade(grade: number): CSSProperties {
-        if (grade >= 5.0) {
+    private styleForGrade(grade: string): CSSProperties {
+        if (grade === "5.0") {
             return { backgroundColor: 'green' }
-        } else if (grade >= 3.0) {
+        } else if (grade === "3.0" || grade === "4.0") {
             return { backgroundColor: '#006400' }
-        } else if (grade >= 2.0) {
+        } else if (grade === "2.0" || grade === "2.5") {
             return { backgroundColor: 'gray' }
-        } else if (grade >= 1.0) {
+        } else if (grade === "1.0") {
             return { backgroundColor: 'orange' }
-        }
+        } else if (grade === "NC") {
+			return { backgroundColor: 'gray' }
+		}
         return { backgroundColor: 'red' }
 
     }
@@ -96,6 +98,9 @@ export default class Airboss extends React.Component<Props, State> {
                     </thead>
                     <tbody>
                         {this.state.currentTraps.map((trap: Trap) => {
+							if (trap.points === "-1.0") {
+								trap.points = "NC"
+							}
                             const gradeStyle = this.styleForGrade(trap.points)
                             return (
                                 <tr style={{ ...styleCell, ...gradeStyle}} key={trap.pilotName + trap.grade + trap.detail}>


### PR DESCRIPTION
Improves WOFD handling on the Greenie Board in the following ways:
-replaces "-1.0" points given by the Airboss for WOFD with NC (no count) (for this, points are now handled as strings)
-renders it with gray background instead of red
![image](https://user-images.githubusercontent.com/56750013/70391822-8351df80-19d9-11ea-82ae-9197145263cf.png)
